### PR TITLE
Update readme.md: exa >> eza

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ A curated list of fantastically awesome command-line software for macOS. This li
 - [colorls](https://github.com/athityakumar/colorls) - Beautify the terminal `ls` command.
 - [dat](https://datproject.org/) - Distributed data sharing tool.
 - [dvm](https://howtowhale.github.io/dvm/) - Install and switch between Docker clients.
-- [exa](https://the.exa.website/) - exa is a modern replacement for ls.
+- [eza](https://eza.rocks/) - eza is a modern, *maintained*, replacement for ls (and exa).
 - [fd](https://github.com/sharkdp/fd) - Simple, fast and user-friendly alternative to find.
 - [lsd](https://github.com/Peltoche/lsd) - The next gen ls command.
 - [navi](https://github.com/denisidoro/navi) - An interactive cheatsheet tool for the command-line.


### PR DESCRIPTION
Updated exa name and link to the maintained fork, eza https://eza.rocks/