### PR TITLE
(update) readme.md with new link to wiki project by prologic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -229,7 +229,7 @@ A curated list of fantastically awesome command-line software for macOS. This li
 - [tmate](https://tmate.io/) - Instant terminal sharing.
 - [upterm](https://github.com/railsware/upterm) - A terminal emulator for the 21st century.
 - [Watchman](https://facebook.github.io/watchman/) - A file watching service.
-- [Wiki](https://github.com/prologic/wiki) -  Self-hosted wiki engine.
+- [Wiki](https://hub.docker.com/r/prologic/wiki) -  Self-hosted wiki engine.
 - [ytop](https://github.com/cjbassi/ytop) - A TUI system monitor written in Rust.
 - [zenith](https://github.com/bvaisvil/zenith) - Like top or htop but with zoom-able charts, network, and disk usage. 
 


### PR DESCRIPTION
The wiki project by prologic is no longer available on their GitHub, but the Docker image is still hosted.